### PR TITLE
Change layman command to reflect repo_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To use this repo,
 add it to your `/etc/portage/repos.conf`
 or use layman like so:
 ```
-# layman -f -o https://raw.github.com/lucy/lucy-overlay/master/repository.xml -a lucy-overlay
+# layman -f -o https://raw.github.com/lucy/lucy-overlay/master/repository.xml -a lucy
 ```
 
 # TODO


### PR DESCRIPTION
Portage complains when the added overlay's name does not reflect the contents of repo_name