### PR TITLE
make `repo_name` agree with `repository.xml`

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-lucy
+lucy-overlay


### PR DESCRIPTION
`repository.xml` has `lucy-overlay`. It's just a matter of deciding which
one to go with; this commit changes `profiles/repo_name` to match.

Fixes #4.